### PR TITLE
Car geometry tweaks

### DIFF
--- a/f1tenth_bringup/config/vesc.yaml
+++ b/f1tenth_bringup/config/vesc.yaml
@@ -34,8 +34,8 @@ vesc_to_odom_node:
     # publish odom to base link tf
     publish_tf: true
     use_servo_cmd_to_calc_angular_velocity: true
-    # car wheelbase is about 31.5cm
-    wheelbase: 0.315
+    # car wheelbase is about 32.5cm
+    wheelbase: 0.325
 
 # No longer needed, all parameters are shared
 # vesc_driver:

--- a/f1tenth_description/gazebo/ackermann.gazebo.xacro
+++ b/f1tenth_description/gazebo/ackermann.gazebo.xacro
@@ -6,19 +6,22 @@
             filename="gz-sim-ackermann-steering-system"
             name="gz::sim::systems::AckermannSteering">
 
-            <left_joint>front_left_wheel_joint</left_joint>
+            <!-- <left_joint>front_left_wheel_joint</left_joint> -->
             <left_joint>rear_left_wheel_joint</left_joint>
-            <right_joint>front_right_wheel_joint</right_joint>
+            <!-- <right_joint>front_right_wheel_joint</right_joint> -->
             <right_joint>rear_right_wheel_joint</right_joint>
             <left_steering_joint>front_left_wheel_steering_joint</left_steering_joint>
             <right_steering_joint>front_right_wheel_steering_joint</right_steering_joint>
 
             <kingpin_width>0.2050</kingpin_width>
-            <steering_limit>0.4667</steering_limit>
+            <steering_limit>0.4347</steering_limit>
+            <!-- https://gazebosim.org/api/gazebo/6/classignition_1_1gazebo_1_1systems_1_1AckermannSteering.html-->
+            <!-- SPECIAL ATTENTION TO STEERING LIMIT-->
+            <!-- USING TAN, check gz-sim source code, turn radius of ~0.7m -->
 
-
-            <wheel_base>0.315</wheel_base>
-            <wheel_separation>0.2050</wheel_separation>
+            <wheel_base>0.325</wheel_base>
+            <!-- SHOULD BE MORE WHEEL SEPERATION I.E. TIRE CENTER-->
+            <wheel_separation>0.2450</wheel_separation>
             <steer_p_gain>10.0</steer_p_gain>
 
             <wheel_radius>0.05475</wheel_radius>

--- a/f1tenth_description/gazebo/ackermann.gazebo.xacro
+++ b/f1tenth_description/gazebo/ackermann.gazebo.xacro
@@ -14,10 +14,10 @@
             <right_steering_joint>front_right_wheel_steering_joint</right_steering_joint>
 
             <kingpin_width>0.2050</kingpin_width>
-            <steering_limit>0.4347</steering_limit>
+            <steering_limit>0.4828</steering_limit>
             <!-- https://gazebosim.org/api/gazebo/6/classignition_1_1gazebo_1_1systems_1_1AckermannSteering.html-->
             <!-- SPECIAL ATTENTION TO STEERING LIMIT-->
-            <!-- USING TAN, check gz-sim source code, turn radius of ~0.7m -->
+            <!-- USING asin(0.325/0.7), check gz-sim source code, turn radius of ~0.7m -->
 
             <wheel_base>0.325</wheel_base>
             <!-- SHOULD BE MORE WHEEL SEPERATION I.E. TIRE CENTER-->

--- a/f1tenth_description/urdf/const.xacro
+++ b/f1tenth_description/urdf/const.xacro
@@ -16,7 +16,7 @@
     <xacro:property name="chassis_height" value="0.09" />
 
     <!-- Joint placement -->
-    <xacro:property name="chassis_to_wheel_x" value="${0.31 /2}" />
+    <xacro:property name="chassis_to_wheel_x" value="${0.325 /2}" />
     <xacro:property name="chassis_to_wheel_y" value="${0.005+ (wheel_width /2) + (chassis_width /2)}" />
     <xacro:property name="chassis_to_wheel_z" value="${wheel_diameter /2}" />
 

--- a/f1tenth_description/urdf/joints.xacro
+++ b/f1tenth_description/urdf/joints.xacro
@@ -7,7 +7,7 @@
         <parent link="base_link" />
 
         <axis xyz="0 0 1" />
-        <limit lower="-0.6" upper="+0.6"
+        <limit lower="-0.7" upper="+0.7"
                velocity="3.66" effort="25" />
         <origin xyz="0.1575 0.1025 0.055" rpy="0 0 0"/>
     </joint>
@@ -17,7 +17,7 @@
         <parent link="base_link" />
 
         <axis xyz="0 0 1" />
-        <limit lower="-0.6" upper="+0.6"
+        <limit lower="-0.7" upper="+0.7"
                velocity="3.66" effort="25" />
         <origin xyz="0.1575 -0.1025 0.055" rpy="0 0 0"/>
     </joint>


### PR DESCRIPTION
- Ackerman in sim now only drive back wheels, reason being the differential simulation in gz for left and right joint in the Ackerman plugin only make sense for the back wheels. This corrected the turning radius in the simulator.
- Corrected wheelbase to better match measurement IRL.
- Corrected 'wheel separation' in sim (shouldn't be the same as kingpin width as per before)